### PR TITLE
Add filter for already built dependencies

### DIFF
--- a/lib/cocoapods-binary/Prebuild.rb
+++ b/lib/cocoapods-binary/Prebuild.rb
@@ -102,8 +102,13 @@ module Pod
                     tars
                 end.flatten
 
-                # add the dendencies
+                # add the dependencies
                 dependency_targets = targets.map {|t| t.recursive_dependent_targets }.flatten.uniq || []
+                # filter already built dependencies
+                dependency_targets = dependency_targets.reject { |t|
+                    local_manifest.version(t.name).to_s.eql? t.version.to_s
+                }
+
                 targets = (targets + dependency_targets).uniq
             else
                 targets = self.pod_targets


### PR DESCRIPTION
Resolves #71 

If version of pod is updated, then there will be an error during `pod install`, eg change version of SVProgressHUD inside development pod Core from `~> 2.0` to = `2.2.0`:

```
[!] CocoaPods could not find compatible versions for pod "SVProgressHUD":
  In snapshot (Podfile.lock):
    SVProgressHUD (= 2.2.5, ~> 2.0)

  In Podfile:
    Core (from `..`) was resolved to 1.0.0, which depends on
      SVProgressHUD (= 2.2.0)

It seems like you've changed the constraints of dependency `SVProgressHUD` inside your development pod `Core`.
You should run `pod update SVProgressHUD` to apply changes you've made.
```