### PR TITLE
Fix The deployment target used to find the right simulator to compile the binaries

### DIFF
--- a/lib/cocoapods-binary/helper/target_checker.rb
+++ b/lib/cocoapods-binary/helper/target_checker.rb
@@ -14,7 +14,7 @@ module Pod
         raw_names = targets_have_different_platforms.map(&:name)
         message = "Oops, you came across a limitation of cocoapods-binary.
 
-The plugin requires that one pod should have ONLY ONE target in the 'Pod.xcodeproj'. There are mainly 2 situations \
+The plugin requires that one pod should have ONLY ONE target in the 'Pods.xcodeproj'. There are mainly 2 situations \
 causing this problem:
 
 1. One pod integrates in 2 or more different platforms' targets. e.g.

--- a/lib/cocoapods-binary/rome/build_framework.rb
+++ b/lib/cocoapods-binary/rome/build_framework.rb
@@ -14,14 +14,13 @@ def build_for_iosish_platform(sandbox,
                               build_dir, 
                               output_path,
                               target, 
+                              deployment_target, 
                               device, 
                               simulator,
                               bitcode_enabled,
                               custom_build_options = [], # Array<String>
                               custom_build_options_simulator = [] # Array<String>
                               )
-
-  deployment_target = target.platform.deployment_target.to_s
   
   target_label = target.label # name with platform if it's used in multiple platforms
   Pod::UI.puts "Prebuilding #{target_label}..."
@@ -51,7 +50,7 @@ def build_for_iosish_platform(sandbox,
   # combine the binaries
   tmp_lipoed_binary_path = "#{build_dir}/#{target_name}"
   lipo_log = `lipo -create -output #{tmp_lipoed_binary_path} #{device_binary} #{simulator_binary}`
-  puts lipo_log unless File.exist?(tmp_lipoed_binary_path)
+  Pod::UI.puts lipo_log unless File.exist?(tmp_lipoed_binary_path)
   FileUtils.mv tmp_lipoed_binary_path, device_binary, :force => true
   
   # collect the swiftmodule file for various archs.
@@ -124,10 +123,10 @@ def xcodebuild(sandbox, target, sdk='macosx', deployment_target=nil, other_optio
               printer.pretty_print(line)
             end
         else
-            raise "shouldn't be handle by xcpretty"
+            raise "shouldn't be handled by xcpretty"
         end
     rescue
-        puts log.red
+        Pod::UI.puts log.red
     end
   end
   [is_succeed, log]
@@ -149,7 +148,7 @@ module Pod
     #         [Pathname] output_path
     #         output path for generated frameworks
     #
-    def self.build(sandbox_root_path, target, output_path, bitcode_enabled = false, custom_build_options=[], custom_build_options_simulator=[])
+    def self.build(sandbox_root_path, target, min_deployment_target, output_path, bitcode_enabled = false, custom_build_options=[], custom_build_options_simulator=[])
     
       return if target.nil?
     
@@ -159,7 +158,7 @@ module Pod
 
       # -- build the framework
       case target.platform.name
-      when :ios then build_for_iosish_platform(sandbox, build_dir, output_path, target, 'iphoneos', 'iphonesimulator', bitcode_enabled, custom_build_options, custom_build_options_simulator)
+      when :ios then build_for_iosish_platform(sandbox, build_dir, output_path, target, min_deployment_target, 'iphoneos', 'iphonesimulator', bitcode_enabled, custom_build_options, custom_build_options_simulator)
       when :osx then xcodebuild(sandbox, target.label, 'macosx', nil, custom_build_options)
       # when :tvos then build_for_iosish_platform(sandbox, build_dir, target, 'appletvos', 'appletvsimulator')
       when :watchos then build_for_iosish_platform(sandbox, build_dir, output_path, target, 'watchos', 'watchsimulator', true, custom_build_options, custom_build_options_simulator)


### PR DESCRIPTION
## Context

* `cocoapods`: 1.6.0
* `cocoapods-binary`: master

## The issue

Currently, when I try to use cocoapods-binary on a project which uses `platform :ios, '11.0'` at the top of its Podfile, `pod install` fails during the prebuild of binary pods because `Fourflusher` finds the older simulator matching `iOS 8.0`, and then `xcodebuild` (Xcode 10.2 on our CircleCI) fails with:

```
xcodebuild: error: Unable to find a destination matching the provided destination specifier:
		{ id:85D2D947-6AFF-469A-9C95-FFBFFB069294 }

	Available destinations for the "AFNetworking" scheme:
		{ platform:iOS Simulator, id:C0DA41D1-EA6C-40A6-AF82-E2D38C2A4503, OS:11.4, name:iPad (5th generation) }
_[...snip...]_
		{ platform:iOS Simulator, id:3D5639A8-8F01-44E3-A3DE-1B4B2C5B3E58, OS:12.2, name:iPhone Xʀ }
```
Where that id `85D2D947-6AFF-469A-9C95-FFBFFB069294` corresponds to a simulator with the `iOS 10.3` runtime when I list `xcrun simctl` on said CI.

## The reason

This is due to the fact that the code uses the `PodTarget.platform.deployment_target` value to determine the minimum deployment target to pass to `Fourflusher::SimControl.new.destination(:oldest, platform, deployment_target)`

As a matter of fact, `target.platform.deployment_target` corresponds to the Pod's **minimum deployment target as defined in its `.podspec`** (or more precisely, the max between '8.0' and the value in the podspec, as seen [here in CocoaPods' source](https://github.com/CocoaPods/CocoaPods/blob/master/lib/cocoapods/installer/analyzer.rb#L788-L794)).

But what is finally used as **the `IPHONEOS_DEPLOYMENT_TARGET` Build Setting for the Pod targets** generated by CocoaPods in the `Pods.xcodeproj` in the end, is the `platform.deployment_target` of the **Aggregate** Targets – as seen [here in CocoaPods source](https://github.com/CocoaPods/CocoaPods/blob/master/lib/cocoapods/installer/xcode/pods_project_generator/project_generator.rb#L106-L110) – and not the `PodTarget` (whose `platform` reflects the one in their spec, not the one for integration). So this is the minimum version we need to use to build the pods

The current behavior means that if we have any pod which have a `s.platforms.ios = '8.0'` in their `podspec`, `cocoapods-binary` will ask `FourFlusher` for a simulator with iOS 8.0 minimum, find for example a 10.3 simulator, but then will fail to compile the Pod target due to its `IPHONEOS_DEPLOYMENT_TARGET=11.0` set on the Pod target – because we used `platform :ios, '11.0'` at the top of our `Podfile`

## The fix

We need to rely on the `platform.deployment_target` of the aggregate target (which will then be used by CocoaPods to set the `IPHONEOS_DEPLOYMENT_TARGET` build setting in each pod's `.xcconfig` file) to determine the right simulator to use for compilation and especially the minimum iOS version that this simulator needs to support.

My solution is to use the maximum value of all the aggregate targets that include the Pod being compiled. That way, if Pod `A` is integrated in our `Podfile` in both in a `target` specifying `platform :ios, '10.0'` and another `target` specifying `platform :ios, '11.0'`, then we'd need to compile `pod A` using an iOS 11 simulator.

## Alternative

We could also instead just use the latest iOS simulator available. After all, what's important for compilation is the SDK version. So if we're using Xcode 10.2 to compile, we should use the latest simulator, one running with iOS SDK 12, because what we care about is the iOS SDK used to compile.

Sadly, after a quick glance at Fourflusher, it seems there's no filter `:newest` to get the most recent simulator, only `:oldest`.