### PR TITLE
Fix copying framework when building a new version

### DIFF
--- a/lib/cocoapods-binary/rome/build_framework.rb
+++ b/lib/cocoapods-binary/rome/build_framework.rb
@@ -42,6 +42,7 @@ def build_for_iosish_platform(sandbox,
   module_name = target.product_module_name
   device_framework_path = "#{build_dir}/#{CONFIGURATION}-#{device}/#{target_name}/#{module_name}.framework"
   simulator_framework_path = "#{build_dir}/#{CONFIGURATION}-#{simulator}/#{target_name}/#{module_name}.framework"
+  output_framework_path = "#{output_path}/#{module_name}.framework"
 
   device_binary = device_framework_path + "/#{module_name}"
   simulator_binary = simulator_framework_path + "/#{module_name}"
@@ -86,6 +87,7 @@ def build_for_iosish_platform(sandbox,
 
   # handle the dSYM files
   device_dsym = "#{device_framework_path}.dSYM"
+  device_dsym_output_path = "#{output_framework_path}.dSYM"
   if File.exist? device_dsym
     # lipo the simulator dsym
     simulator_dsym = "#{simulator_framework_path}.dSYM"
@@ -96,12 +98,14 @@ def build_for_iosish_platform(sandbox,
       FileUtils.mv tmp_lipoed_binary_path, "#{device_framework_path}.dSYM/Contents/Resources/DWARF/#{module_name}", :force => true
     end
     # move
-    FileUtils.mv device_dsym, output_path, :force => true
+    FileUtils.rm_r device_dsym_output_path if Dir.exist? device_dsym_output_path
+    File.rename device_dsym, device_dsym_output_path
   end
 
   # output
   output_path.mkpath unless output_path.exist?
-  FileUtils.mv device_framework_path, output_path, :force => true
+  FileUtils.rm_r output_framework_path if Dir.exist? output_framework_path
+  File.rename device_framework_path, output_framework_path
 
 end
 


### PR DESCRIPTION
Fixes an issue where copying the generated framework after a build would fail if the framework already exists in the GeneratedFrameworks folder, even if that existing framework is out-of-date.

This issue is caused by `FileUtils.mv` exibiting different behavior for files than for directories. If the destination already exists and is a file then `:force => true` causes `FileUtils.mv` to remove the destination and proceed with the move as expected. However, if the destination already exists and is a directory, then `FileUtils.mv` raises an error and by specifying the `:force => true` flag, that error is swallowed. This effectively results in a silent failure of the `FileUtils.mv` command if the destination already exists and is a directory (yet works as expected if it's a file).