### PR TITLE
Fix path for old_read_link

### DIFF
--- a/lib/cocoapods-binary/Integration.rb
+++ b/lib/cocoapods-binary/Integration.rb
@@ -269,7 +269,7 @@ module Pod
                     # If the path isn't an absolute path, we add a realtive prefix.
                     old_read_link=`which readlink`
                     readlink () {
-                        path=`$old_read_link $1`;
+                        path=`$old_read_link "$1"`;
                         if [ $(echo "$path" | cut -c 1-1) = '/' ]; then
                             echo $path;
                         else


### PR DESCRIPTION
Wraps the path in double quotes for it to work with paths that include spaces.