### PR TITLE
Allows using custom archs in `custom_build_options_simulator`

### DIFF
--- a/lib/cocoapods-binary/rome/build_framework.rb
+++ b/lib/cocoapods-binary/rome/build_framework.rb
@@ -29,8 +29,13 @@ def build_for_iosish_platform(sandbox,
   other_options = []
   # bitcode enabled
   other_options += ['BITCODE_GENERATION_MODE=bitcode'] if bitcode_enabled
-  # make less arch to iphone simulator for faster build
-  custom_build_options_simulator += ['ARCHS=x86_64', 'ONLY_ACTIVE_ARCH=NO'] if simulator == 'iphonesimulator'
+
+  # make less arch to iphone simulator for faster build if there is no options in `custom_build_options_simulator`
+  if simulator == 'iphonesimulator'
+    joined_options = custom_build_options_simulator.join(' ')
+    custom_build_options_simulator << 'ONLY_ACTIVE_ARCH=NO' unless joined_options.include?('ONLY_ACTIVE_ARCH')
+    custom_build_options_simulator << 'ARCHS=x86_64' unless joined_options.include?('ARCHS')
+  end
 
   is_succeed, _ = xcodebuild(sandbox, target_label, device, deployment_target, other_options + custom_build_options)
   exit 1 unless is_succeed
@@ -110,6 +115,7 @@ def xcodebuild(sandbox, target, sdk='macosx', deployment_target=nil, other_optio
   platform = PLATFORMS[sdk]
   args += Fourflusher::SimControl.new.destination(:oldest, platform, deployment_target) unless platform.nil?
   args += other_options
+  args.map! { |arg| arg.include?(' ') ? "\'#{arg}\'" : arg }
   log = `xcodebuild #{args.join(" ")} 2>&1`
   exit_code = $?.exitstatus  # Process::Status
   is_succeed = (exit_code == 0)


### PR DESCRIPTION
Resolves issue https://github.com/leavez/cocoapods-binary/issues/93.

It will allow using `set_custom_xcodebuild_options_for_prebuilt_frameworks :simulator => "ARCHS=x86_64 i386"` in the Podfile if you need i386 architecture, e.g. for iPhone 5 simulator.