### PR TITLE
Fix handling spaces in source path

### DIFF
--- a/lib/cocoapods-binary/Integration.rb
+++ b/lib/cocoapods-binary/Integration.rb
@@ -269,7 +269,7 @@ module Pod
                     # If the path isn't an absolute path, we add a realtive prefix.
                     old_read_link=`which readlink`
                     readlink () {
-                        path=`$old_read_link $1`;
+                        path=`$old_read_link "$1"`;
                         if [ $(echo "$path" | cut -c 1-1) = '/' ]; then
                             echo $path;
                         else


### PR DESCRIPTION
This PR fixes handling spaces in source path. 
Bug happens e.g. when scheme name contains a space, in our case when you add environment name to app name ("AppName Test", "AppName Release" etc.)