### PR TITLE
Fix license warning with subspecs

### DIFF
--- a/lib/cocoapods-binary/Integration.rb
+++ b/lib/cocoapods-binary/Integration.rb
@@ -217,7 +217,7 @@ module Pod
                 end
 
                 # to avoid the warning of missing license
-                spec.attributes_hash["license"] = {}
+                spec.root.attributes_hash["license"] = {}
 
             end
 


### PR DESCRIPTION
`CocoaPods-binary` removes the `license` attribute from the podspec attributes hash since it doesn't copy the license file over. However, the `license` attribute in only valid in the root spec of a podspec.

There is currently a bug where if you specify a dependency on a subspec of a pod, then `cocoapods-binary` removes the `license` attribute not from the root spec, but from the subspec, thus leaving the `license` attribute in the root spec intact. This produces the following warning:
```
[!] Unable to read the license file `LICENSE` for the spec `<PodName> (<PodVersion>)`
```

This PR fixes this bug by using the root spec when removing the `license` attribute.