### PR TITLE
Fix issue with IRGen

### DIFF
--- a/lib/cocoapods-binary/Prebuild.rb
+++ b/lib/cocoapods-binary/Prebuild.rb
@@ -123,7 +123,14 @@ module Pod
 
                 output_path = sandbox.framework_folder_path_for_target_name(target.name)
                 output_path.mkpath unless output_path.exist?
-                Pod::Prebuild.build(sandbox_path, target, output_path, bitcode_enabled,  Podfile::DSL.custom_build_options,  Podfile::DSL.custom_build_options_simulator)
+                
+                min_deployment_target = aggregate_targets
+                    .select { |t| t.pod_targets.include?(target) }
+                    .map(&:platform)
+                    .map(&:deployment_target)
+                    .max
+
+                Pod::Prebuild.build(sandbox_path, target, min_deployment_target, output_path, bitcode_enabled,  Podfile::DSL.custom_build_options,  Podfile::DSL.custom_build_options_simulator)
 
                 # save the resource paths for later installing
                 if target.static_framework? and !target.resource_paths.empty?

--- a/lib/cocoapods-binary/rome/build_framework.rb
+++ b/lib/cocoapods-binary/rome/build_framework.rb
@@ -188,7 +188,7 @@ module Pod
     
     def self.remove_build_dir(sandbox_root)
       path = build_dir(sandbox_root)
-      path.rmtree if path.exist?
+      # path.rmtree if path.exist?
     end
 
     private 


### PR DESCRIPTION
During debugging session, with the use of pods installed via Cocoapods-binary, the console in Xcode displays error messages while executing following expression:
`po self`

The error looks the following one:
```
Printing description of self:
expression produced error: error: virtual filesystem overlay file '/path/to/project/Pods/build/Pods.build/Release-iphoneos/Charts.build/all-product-headers.yaml' not found

error: couldn't IRGen expression. Please check the above error messages for possible root causes.
```

The issue is not related to Charts pod, but to every pod used.

To fix the issue, I just removed the line that delete the build folder generated during the precompiling of pods. This folder contains for each pod, the `all-product-headers.yaml` expected by Xcode.