### PR TITLE
Preserve license files, for inclusion in acknowledgements

### DIFF
--- a/lib/cocoapods-binary/Integration.rb
+++ b/lib/cocoapods-binary/Integration.rb
@@ -216,9 +216,6 @@ module Pod
                     spec.attributes_hash["resources"] += bundle_names.map{|n| n+".bundle"}
                 end
 
-                # to avoid the warning of missing license
-                spec.attributes_hash["license"] = {}
-
             end
 
         end

--- a/lib/cocoapods-binary/Prebuild.rb
+++ b/lib/cocoapods-binary/Prebuild.rb
@@ -156,7 +156,7 @@ module Pod
             Pod::Prebuild.remove_build_dir(sandbox_path)
 
 
-            # copy vendored libraries and frameworks
+            # copy vendored libraries and frameworks as well as any license
             targets.each do |target|
                 root_path = self.sandbox.pod_dir(target.name)
                 target_folder = sandbox.framework_folder_path_for_target_name(target.name)
@@ -171,14 +171,15 @@ module Pod
 
                 target.spec_consumers.each do |consumer|
                     file_accessor = Sandbox::FileAccessor.new(root_path, consumer)
-                    lib_paths = file_accessor.vendored_frameworks || []
-                    lib_paths += file_accessor.vendored_libraries
+                    preserve_paths = file_accessor.vendored_frameworks || []
+                    preserve_paths += file_accessor.vendored_libraries
+                    preserve_paths << file_accessor.license if file_accessor.license
                     # @TODO dSYM files
-                    lib_paths.each do |lib_path|
-                        relative = lib_path.relative_path_from(root_path)
+                    preserve_paths.each do |path|
+                        relative = path.relative_path_from(root_path)
                         destination = target_folder + relative
                         destination.dirname.mkpath unless destination.dirname.exist?
-                        FileUtils.cp_r(lib_path, destination, :remove_destination => true)
+                        FileUtils.cp_r(path, destination, :remove_destination => true)
                     end
                 end
             end

--- a/lib/cocoapods-binary/rome/build_framework.rb
+++ b/lib/cocoapods-binary/rome/build_framework.rb
@@ -42,6 +42,11 @@ def build_for_iosish_platform(sandbox,
   module_name = target.product_module_name
   device_framework_path = "#{build_dir}/#{CONFIGURATION}-#{device}/#{target_name}/#{module_name}.framework"
   simulator_framework_path = "#{build_dir}/#{CONFIGURATION}-#{simulator}/#{target_name}/#{module_name}.framework"
+  if !File.directory?(device_framework_path)
+    # Newer Xcodes seem to build all in one directory.
+    device_framework_path = "#{build_dir}/#{CONFIGURATION}-#{device}/#{module_name}.framework"
+    simulator_framework_path = "#{build_dir}/#{CONFIGURATION}-#{simulator}/#{module_name}.framework"
+  end
 
   device_binary = device_framework_path + "/#{module_name}"
   simulator_binary = simulator_framework_path + "/#{module_name}"


### PR DESCRIPTION
Also check top-level build directories as well as target-specific ones; the build path seems to have changed in newer versions of Xcode.