### PR TITLE
Fix path to compiled xib file

### DIFF
--- a/lib/cocoapods-binary/Integration.rb
+++ b/lib/cocoapods-binary/Integration.rb
@@ -88,7 +88,16 @@ module Pod
                     path_objects = hash[name]
                     if path_objects != nil
                         path_objects.each do |object|
-                            make_link(object.real_file_path, object.target_file_path)
+                            target_file_path = object.target_file_path
+                            real_file_path = object.real_file_path
+
+                            case File.extname(real_file_path)
+                            when '.xib'
+                                real_file_path = real_file_path.sub_ext(".nib")
+                                target_file_path = target_file_path.sub(".xib", ".nib")
+                            end
+
+                            make_link(real_file_path, target_file_path)
                         end
                     end
                 end # of for each 


### PR DESCRIPTION
`.xib` file is compiled as `.nib`, so fix path on making symbolic link.
Actually I copied an pasted code from https://github.com/grab/cocoapods-binary-cache/commit/1ac05cd4f0528e86d0d6fa7f080882d16363dfb4
