### PR TITLE
Fix coding error in Prebuild.rb

### DIFF
--- a/lib/cocoapods-binary/Prebuild.rb
+++ b/lib/cocoapods-binary/Prebuild.rb
@@ -97,7 +97,7 @@ module Pod
                 targets = root_names_to_update.map do |pod_name|
                     tars = Pod.fast_get_targets_for_pod_name(pod_name, self.pod_targets, cache)
                     if tars.nil? || tars.empty?
-                        raise "There's no target named (#{pod_name}) in Pod.xcodeproj.\n #{self.pod_targets.map(&:name)}" if t.nil?
+                        raise "There's no target named (#{pod_name}) in Pod.xcodeproj.\n #{self.pod_targets.map(&:name)}" if tars.nil?
                     end
                     tars
                 end.flatten


### PR DESCRIPTION
The follow error was encountered when attempting to `pod install` after removing a dependency from the `PodFile`.  The error highlights that there is an `undefined local variable`.  Looking at `Prebuild.rb` you can see that the variable `t` should be `tars`. 

```
NameError - undefined local variable or method `t' for #<Pod::Installer:0x00007fc7442f7980>
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cocoapods-binary/lib/cocoapods-binary/Prebuild.rb:134:in `block in prebuild_frameworks!'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/2.7.0/set.rb:328:in `each_key'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/2.7.0/set.rb:328:in `each'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cocoapods-binary/lib/cocoapods-binary/Prebuild.rb:131:in `map'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cocoapods-binary/lib/cocoapods-binary/Prebuild.rb:131:in `prebuild_frameworks!'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cocoapods-binary/lib/cocoapods-binary/Prebuild.rb:325:in `block in <class:Installer>'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cocoapods-1.10.1/lib/cocoapods/installer.rb:612:in `perform_post_install_actions'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cocoapods-1.10.1/lib/cocoapods/installer.rb:169:in `install!'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cocoapods-binary/lib/cocoapods-binary/Main.rb:140:in `block in <top (required)>'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cocoapods-1.10.1/lib/cocoapods/hooks_manager.rb:124:in `block (3 levels) in run'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cocoapods-1.10.1/lib/cocoapods/user_interface.rb:145:in `message'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cocoapods-1.10.1/lib/cocoapods/hooks_manager.rb:116:in `block (2 levels) in run'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cocoapods-1.10.1/lib/cocoapods/hooks_manager.rb:115:in `each'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cocoapods-1.10.1/lib/cocoapods/hooks_manager.rb:115:in `block in run'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cocoapods-1.10.1/lib/cocoapods/user_interface.rb:145:in `message'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cocoapods-1.10.1/lib/cocoapods/hooks_manager.rb:114:in `run'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cocoapods-1.10.1/lib/cocoapods/installer.rb:604:in `run_plugins_pre_install_hooks'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cocoapods-1.10.1/lib/cocoapods/installer.rb:224:in `block in prepare'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cocoapods-1.10.1/lib/cocoapods/user_interface.rb:145:in `message'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cocoapods-1.10.1/lib/cocoapods/installer.rb:220:in `prepare'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cocoapods-1.10.1/lib/cocoapods/installer.rb:159:in `install!'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cocoapods-1.10.1/lib/cocoapods/command/install.rb:52:in `run'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/claide-1.0.3/lib/claide/command.rb:334:in `run'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cocoapods-1.10.1/lib/cocoapods/command.rb:52:in `run'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/cocoapods-1.10.1/bin/pod:55:in `<top (required)>'
/Users/okp/.rbenv/versions/2.7.1/bin/pod:23:in `load'
/Users/okp/.rbenv/versions/2.7.1/bin/pod:23:in `<top (required)>'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.2.4/lib/bundler/cli/exec.rb:63:in `load'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.2.4/lib/bundler/cli/exec.rb:63:in `kernel_load'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.2.4/lib/bundler/cli/exec.rb:28:in `run'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.2.4/lib/bundler/cli.rb:494:in `exec'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.2.4/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.2.4/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.2.4/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.2.4/lib/bundler/cli.rb:30:in `dispatch'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.2.4/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.2.4/lib/bundler/cli.rb:24:in `start'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.2.4/exe/bundle:49:in `block in <top (required)>'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.2.4/lib/bundler/friendly_errors.rb:130:in `with_friendly_errors'
/Users/okp/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.2.4/exe/bundle:37:in `<top (required)>'
/Users/okp/.rbenv/versions/2.7.1/bin/bundle:23:in `load'
/Users/okp/.rbenv/versions/2.7.1/bin/bundle:23:in `<main>'
```
```